### PR TITLE
fix issue with fabric: http://bugs.mysql.com/bug.php?id=72281

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -52,6 +52,8 @@ if [ "$1" = 'mysqld' ]; then
 
 		tempSqlFile=$(mktemp /tmp/mysql-first-time.XXXXXX.sql)
 		cat > "$tempSqlFile" <<-EOSQL
+			-- What's done in this file shouldn't be replicated
+			SET @@SESSION.SQL_LOG_BIN=0;
 			DELETE FROM mysql.user ;
 			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
 			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;


### PR DESCRIPTION
As of now you can't use this image to create fabric clusters.

The patch removes from binlog the setup queries (eg. creating users)

Signed-off-by: Roberto Polli roberto.polli@par-tec.it
