### PR TITLE
Added startup check

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -7,6 +7,16 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'mysqld' ]; then
+	# Test we're able to startup without errors. We redirect stdout to /dev/null so
+	# only the error messages are left.
+	result=0
+	output=$("$@" --verbose --help 2>&1 > /dev/null) || result=$?
+	if [ ! "$result" = "0" ]; then
+		echo >&2 'error: could not run mysql. This could be caused by a misconfigured my.cnf'
+		echo >&2 "$output"
+		exit 1
+	fi
+
 	# Get config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -7,6 +7,16 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'mysqld' ]; then
+	# Test we're able to startup without errors. We redirect stdout to /dev/null so
+	# only the error messages are left.
+	result=0
+	output=$("$@" --verbose --help 2>&1 > /dev/null) || result=$?
+	if [ ! "$result" = "0" ]; then
+		echo >&2 'error: could not run mysql. This could be caused by a misconfigured my.cnf'
+		echo >&2 "$output"
+		exit 1
+	fi
+
 	# Get config
 	DATADIR="$("$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -7,6 +7,16 @@ if [ "${1:0:1}" = '-' ]; then
 fi
 
 if [ "$1" = 'mysqld' ]; then
+	# Test we're able to startup without errors. We redirect stdout to /dev/null so
+	# only the error messages are left.
+	result=0
+	output=$("$@" --verbose --help 2>&1 > /dev/null) || result=$?
+	if [ ! "$result" = "0" ]; then
+		echo >&2 'error: could not run mysql. This could be caused by a misconfigured my.cnf'
+		echo >&2 "$output"
+		exit 1
+	fi
+
 	# Get config
 	DATADIR="$("$@" --verbose --help --log-bin-index=/tmp/tmp.index 2>/dev/null | awk '$1 == "datadir" { print $2; exit }')"
 


### PR DESCRIPTION
Added a check to see if we're able to testrun mysqld. This avoids some ambiguous errors that could arise further down the line. One such example would be when a user has supplied a custom my.cnf which is misconfigured. As it currently is, this will make the script crash without no detailed error message of what caused the crash. With this change, the script will error out immediately and provide a clear message to the user of what went wrong.
