### PR TITLE
add volume for docker-entrypoint-initdb.d to mount users init scripts

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -24,6 +24,7 @@ RUN rpmkeys --import https://repo.mysql.com/RPM-GPG-KEY-mysql \
   && mkdir /docker-entrypoint-initdb.d
 
 VOLUME /var/lib/mysql
+VOLUME /docker-entrypoint-initdb.d
 
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -24,6 +24,7 @@ RUN rpmkeys --import https://repo.mysql.com/RPM-GPG-KEY-mysql \
   && mkdir /docker-entrypoint-initdb.d
 
 VOLUME /var/lib/mysql
+VOLUME /docker-entrypoint-initdb.d
 
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh

--- a/5.7/Dockerfile
+++ b/5.7/Dockerfile
@@ -24,6 +24,7 @@ RUN rpmkeys --import https://repo.mysql.com/RPM-GPG-KEY-mysql \
   && mkdir /docker-entrypoint-initdb.d
 
 VOLUME /var/lib/mysql
+VOLUME /docker-entrypoint-initdb.d
 
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -24,6 +24,7 @@ RUN rpmkeys --import https://repo.mysql.com/RPM-GPG-KEY-mysql \
   && mkdir /docker-entrypoint-initdb.d
 
 VOLUME /var/lib/mysql
+VOLUME /docker-entrypoint-initdb.d
 
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -24,6 +24,7 @@ RUN rpmkeys --import https://repo.mysql.com/RPM-GPG-KEY-mysql \
   && mkdir /docker-entrypoint-initdb.d
 
 VOLUME /var/lib/mysql
+VOLUME /docker-entrypoint-initdb.d
 
 COPY docker-entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh


### PR DESCRIPTION
This allows user to add initial sql scripts simply mounting a volume, without creating a new Dockerfile. Ithis gives possibility to create multiple schemas in single conteiner, that is beter than create container for each schema.