### PR TITLE
Allow setting MYSQL_PASSWORD via file contents.

### DIFF
--- a/5.5/docker-entrypoint.sh
+++ b/5.5/docker-entrypoint.sh
@@ -136,6 +136,13 @@ EOF
 		fi
 
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+                        if [ -f "$MYSQL_PASSWORD" ]; then
+                                MYSQL_PASSWORD="$(cat $MYSQL_PASSWORD)"
+                                if [ -z "$MYSQL_PASSWORD" ]; then
+                                        echo >&2 '[Entrypoint] Empty MYSQL_PASSWORD file specified.'
+                                        exit 1
+                                fi
+                        fi
 			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" | "${mysql[@]}"
 
 			if [ "$MYSQL_DATABASE" ]; then

--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -136,6 +136,13 @@ EOF
 		fi
 
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+                        if [ -f "$MYSQL_PASSWORD" ]; then
+                                MYSQL_PASSWORD="$(cat $MYSQL_PASSWORD)"
+                                if [ -z "$MYSQL_PASSWORD" ]; then
+                                        echo >&2 '[Entrypoint] Empty MYSQL_PASSWORD file specified.'
+                                        exit 1
+                                fi
+                        fi
 			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" | "${mysql[@]}"
 
 			if [ "$MYSQL_DATABASE" ]; then

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -136,6 +136,13 @@ EOF
 		fi
 
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+                        if [ -f "$MYSQL_PASSWORD" ]; then
+                                MYSQL_PASSWORD="$(cat $MYSQL_PASSWORD)"
+                                if [ -z "$MYSQL_PASSWORD" ]; then
+                                        echo >&2 '[Entrypoint] Empty MYSQL_PASSWORD file specified.'
+                                        exit 1
+                                fi
+                        fi
 			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" | "${mysql[@]}"
 
 			if [ "$MYSQL_DATABASE" ]; then

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -136,6 +136,13 @@ EOF
 		fi
 
 		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+                        if [ -f "$MYSQL_PASSWORD" ]; then
+                                MYSQL_PASSWORD="$(cat $MYSQL_PASSWORD)"
+                                if [ -z "$MYSQL_PASSWORD" ]; then
+                                        echo >&2 '[Entrypoint] Empty MYSQL_PASSWORD file specified.'
+                                        exit 1
+                                fi
+                        fi
 			echo "CREATE USER '"$MYSQL_USER"'@'%' IDENTIFIED BY '"$MYSQL_PASSWORD"' ;" | "${mysql[@]}"
 
 			if [ "$MYSQL_DATABASE" ]; then

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ When you create a MySQL Server container, you can configure the MySQL instance b
 
 -   `MYSQL_USER`, `MYSQL_PASSWORD`: These variables are used in conjunction to create a user and set that user's password, and the user is granted superuser permissions for the database specified by the `MYSQL_DATABASE` variable. Both `MYSQL_USER` and `MYSQL_PASSWORD` are required for a user to be created; if any of the two variables is not set, the other is ignored. If both variables are set but `MYSQL_DATABASE` is not, the user is created without any privileges.
 
+    > **Warning**
+    >
+    > Setting the user's password on the command line is insecure. As an alternative to specifying the password explicitly, you can set the variable with a container file path for a password file, and then mount a file from your host that contains the password at the container file path.
+
     > **Note**
     >
     > There is no need to use this mechanism to create the root superuser, which is created by default with the password set by either one of the mechanisms discussed in the descriptions for `MYSQL_ROOT_PASSWORD` and `MYSQL_RANDOM_ROOT_PASSWORD`, unless `MYSQL_ALLOW_EMPTY_PASSWORD` is true.


### PR DESCRIPTION
This is analagous to what is done with `MYSQL_ROOT_PASSWORD`. If
`MYSQL_PASSWORD` is an existing file path, then use the contents
of the file as the value for the password when creating a
non-root user.

This makes it possible to use Docker secrets as a way to pass
this particular credential into the `mysql-server` container.