### PR TITLE
Make MYSQL_INNODB_NUM_MEMBERS work with offline members

### DIFF
--- a/8.0/run.sh
+++ b/8.0/run.sh
@@ -38,7 +38,7 @@ if [ "$1" = 'mysqlrouter' ]; then
     done
     echo "Succesfully contacted mysql server at $MYSQL_HOST. Checking for cluster state."
     attempt_num=0
-    until [ "$(mysql -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" -h "$MYSQL_HOST" -P "$MYSQL_PORT" -N performance_schema -e "select count(MEMBER_STATE) = $MYSQL_INNODB_NUM_MEMBERS from replication_group_members where MEMBER_STATE = 'ONLINE';" 2> /dev/null)" -eq 1 ]; do
+    until [ "$(mysql -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" -h "$MYSQL_HOST" -P "$MYSQL_PORT" -N mysql_innodb_cluster_metadata -e "select count(*) = $MYSQL_INNODB_NUM_MEMBERS FROM instances WHERE replicaset_id = (SELECT replicaset_id FROM instances WHERE mysql_server_uuid = @@server_uuid);" 2> /dev/null)" -eq 1 ]; do
 	    echo "Waiting for $MYSQL_INNODB_NUM_MEMBERS cluster instances to become available via $MYSQL_HOST ($attempt_num/$max_tries)"
 	    sleep $(( attempt_num++ ))
 	    if (( attempt_num == max_tries )); then


### PR DESCRIPTION
Hello,

I am facing some issues dealing with this image in production, in particular around the semantics of `MYSQL_INNODB_NUM_MEMBERS`. Specifically, the container fails to start until exactly `MYSQL_INNODB_NUM_MEMBERS` members are part of the cluster and online. In my case, such number is set to 3, and the setup is a standard single primary InnoDB Cluster.

This creates a problem because, if one mysql replica goes down, the cluster is still healthy since it still has a quorum (though it won't be tolerant to further failures, but that might not be an imminent problem), but even if it's healthy, starting new Router containers will fail, because they will be stuck waiting for the missing replica to come up. This severely limits the availability of Router, especially when Router itself gets deployed alongside the client application (as recommended in the official documentation), which might be subject to a very frequent deployment cycle, even when a mysql replica is down.

Looking a bit deeper at the implementation of the container, the variable `MYSQL_INNODB_NUM_MEMBERS` is used in the docker entrypoint as such:

```
select count(MEMBER_STATE) = $MYSQL_INNODB_NUM_MEMBERS from replication_group_members where MEMBER_STATE = 'ONLINE';
```

So, we don't proceed with the initialization until `MYSQL_INNODB_NUM_MEMBERS` are up and online.

My first attempt to solve this was to relax this query to the following:

```
select count(MEMBER_STATE) = $MYSQL_INNODB_NUM_MEMBERS from replication_group_members
```

This doesn't work, because `replication_group_members` entries are removed if a member of the cluster goes down, so if I temporarily lose one replica, the table shows up just two entries.

In other words, if I bring down the `mysql3` container, I go from:

```
mysql> select * from performance_schema.replication_group_members;
+---------------------------+--------------------------------------+-------------+-------------+--------------+-------------+----------------+
| CHANNEL_NAME              | MEMBER_ID                            | MEMBER_HOST | MEMBER_PORT | MEMBER_STATE | MEMBER_ROLE | MEMBER_VERSION |
+---------------------------+--------------------------------------+-------------+-------------+--------------+-------------+----------------+
| group_replication_applier | 0120d6f4-bb57-11e8-a2e8-0242ac110003 | mysql1      |        3306 | ONLINE       | PRIMARY     | 8.0.12         |
| group_replication_applier | 026bb327-bb57-11e8-b03c-0242ac110004 | mysql2      |        3306 | ONLINE       | SECONDARY   | 8.0.12         |
| group_replication_applier | 02914fbf-bb57-11e8-b455-0242ac110005 | mysql3      |        3306 | ONLINE       | SECONDARY   | 8.0.12         |
+---------------------------+--------------------------------------+-------------+-------------+--------------+-------------+----------------+
3 rows in set (0.00 sec)
```

To:

```
mysql> select * from performance_schema.replication_group_members;
+---------------------------+--------------------------------------+-------------+-------------+--------------+-------------+----------------+
| CHANNEL_NAME              | MEMBER_ID                            | MEMBER_HOST | MEMBER_PORT | MEMBER_STATE | MEMBER_ROLE | MEMBER_VERSION |
+---------------------------+--------------------------------------+-------------+-------------+--------------+-------------+----------------+
| group_replication_applier | 0120d6f4-bb57-11e8-a2e8-0242ac110003 | mysql1      |        3306 | ONLINE       | PRIMARY     | 8.0.12         |
| group_replication_applier | 026bb327-bb57-11e8-b03c-0242ac110004 | mysql2      |        3306 | ONLINE       | SECONDARY   | 8.0.12         |
+---------------------------+--------------------------------------+-------------+-------------+--------------+-------------+----------------+
2 rows in set (0.00 sec)
```

So that's not a viable solution. Another attempt to relax the entrypoint constraint was to wait until **at least** (and not **exactly**) `N` members are online, so I could just pass `MYSQL_INNODB_NUM_MEMBERS=1` and the underlying query would be:

```
select count(MEMBER_STATE) >= $MYSQL_INNODB_NUM_MEMBERS from replication_group_members where MEMBER_STATE = 'ONLINE';
```

Upon first inspection, this worked, because Router will dynamically discover the other cluster members at runtime via the bootstrap server, and properly route the traffic through the right master, so it doesn't matter if we end up with a configuration file containing a single bootstrap server:

```
$ docker exec -it mysql-router cat /tmp/mysqlrouter/mysqlrouter.conf
# File automatically generated during MySQL Router bootstrap
[metadata_cache:test]
bootstrap_server_addresses=mysql://mysql1:3306
...
```

However, it seems that all the cluster state is always discovered **only** via the bootstrap nodes. This means that if the original node discovered during the bootstrap goes down, the entire thing goes down, Router stops serving all the requests, even if we have a valid cluster formed by mysql2 and mysql3:

```
2018-09-13 18:31:17 metadata_cache WARNING [7f7ec54c2700] Replicaset 'default' not available
2018-09-13 18:31:17 routing WARNING [7f7ec54c2700] No available servers found for 'default' primary routing
```

So, also this option is not viable (or better, it would be viable just if we introduced an explicitly dependency between Router and the mysql instances, making sure that Router is started after the cluster is fully formed for the first time, which seems annoying).

The third option that I found was to actually not rely on the `replication_group_members` table, but to actually rely on the exact same table that Router internally uses during the bootstrap process to discover the members of the cluster (https://github.com/mysql/mysql-router/blob/8.0/src/router/src/config_generator.cc#L1328). This table has the advantage that all the members are always listed, even if one is down:

```
mysql> select * from mysql_innodb_cluster_metadata.instances;
+-------------+---------+---------------+--------------------------------------+---------------+------+--------+--------------------------------------------------------------------------------------+------------+---------------+-------------+
| instance_id | host_id | replicaset_id | mysql_server_uuid                    | instance_name | role | weight | addresses                                                                            | attributes | version_token | description |
+-------------+---------+---------------+--------------------------------------+---------------+------+--------+--------------------------------------------------------------------------------------+------------+---------------+-------------+
|           1 |       1 |             1 | 42dd80ee-bb64-11e8-b479-0242ac110003 | mysql1:3306   | HA   |   NULL | {"mysqlX": "mysql1:33060", "grLocal": "mysql1:33061", "mysqlClassic": "mysql1:3306"} | NULL       |          NULL | NULL        |
|           8 |       8 |             1 | 456b4ebd-bb64-11e8-9a17-0242ac110004 | mysql2:3306   | HA   |   NULL | {"mysqlX": "mysql2:33060", "grLocal": "mysql2:33061", "mysqlClassic": "mysql2:3306"} | NULL       |          NULL | NULL        |
|          15 |      15 |             1 | 46845bc1-bb64-11e8-841f-0242ac110005 | mysql3:3306   | HA   |   NULL | {"mysqlX": "mysql3:33060", "grLocal": "mysql3:33061", "mysqlClassic": "mysql3:3306"} | NULL       |          NULL | NULL        |
+-------------+---------+---------------+--------------------------------------+---------------+------+--------+--------------------------------------------------------------------------------------+------------+---------------+-------------+
3 rows in set (0.00 sec)
```

So, if we use this table with `MYSQL_INNODB_NUM_MEMBERS=3`, we can effectively make sure that Router, just like before, doesn't come up until **all** the bootstrap server addresses can be properly discovered by the bootstrap process, but we also become more tolerant to a replica going temporarily down, since Router can be safely started from scratch in that scenario. So, the query that I'm using, adapted from the C++ code in the link, is: 

```
select count(*) = $MYSQL_INNODB_NUM_MEMBERS FROM mysql_innodb_cluster_metadata.instances WHERE replicaset_id = (SELECT replicaset_id FROM mysql_innodb_cluster_metadata.instances WHERE mysql_server_uuid = @@server_uuid);
```

What do you think? I'm not familiar too familiar with Router so I would be interested to know if I missed some corner case.