### PR TITLE
Bootstrap with --force

### DIFF
--- a/8.0/run.sh
+++ b/8.0/run.sh
@@ -46,7 +46,7 @@ if [ "$1" = 'mysqlrouter' ]; then
 	    fi
     done
     echo "Succesfully contacted cluster with $MYSQL_INNODB_NUM_MEMBERS members. Bootstrapping."
-    mysqlrouter --bootstrap "$MYSQL_USER@$MYSQL_HOST:$MYSQL_PORT" --user=mysqlrouter --directory /tmp/mysqlrouter <<< "$MYSQL_PASSWORD"
+    mysqlrouter --bootstrap "$MYSQL_USER@$MYSQL_HOST:$MYSQL_PORT" --user=mysqlrouter --directory /tmp/mysqlrouter --force <<< "$MYSQL_PASSWORD"
     sed -i -e 's/logging_folder=.*$/logging_folder=/' /tmp/mysqlrouter/mysqlrouter.conf
     echo "Starting mysql-router."
     exec "$@" --config /tmp/mysqlrouter/mysqlrouter.conf


### PR DESCRIPTION
Since the container image always does the bootstrap when it starts, we can end up in a situation where the container is restarted while it preserves its previous hostname (e.g. container restarted in a Kubernetes pod). This causes the bootstrap process to fail, because Router will already find an
entry matching the existing hostname inside the `mysql_innodb_cluster_metadata.hosts` table, so it will fail with:

```
Error: It appears that a router instance named '' has been previously
configured in this host. If that instance no longer exists, use the --force
option to overwrite it.
```

It seems the only sensible option to be resilient to this sort of failure is to bootstrap with --force, so that the registration can be properly reclaimed.
