### PR TITLE
Unset the variable, not the value of the variable

### DIFF
--- a/8.0/run.sh
+++ b/8.0/run.sh
@@ -27,7 +27,7 @@ if [ "$1" = 'mysqlrouter' ]; then
     fi
 
     echo $MYSQL_PASSWORD > /tmp/mysqlrouter-pass
-    unset $MYSQL_PASSWORD
+    unset MYSQL_PASSWORD
     max_tries=12
     attempt_num=0
     until (echo > "/dev/tcp/$MYSQL_HOST/$MYSQL_PORT") >/dev/null 2>&1; do


### PR DESCRIPTION
Hi there! This was causing my wordpress pod in kubernetes to fail because

```
kubectl logs -f wordpress-router-55d58cc948-jphzk -c mysqlrouter 
+ exec /run.sh mysqlrouter
/run.sh: line 30: unset: `my-super-secret-pass': not a valid identifier
```