### PR TITLE
MYSQL_RANDOM_ROOT_PASSWORD: don't treat "no" as "yes"

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -103,7 +103,7 @@ if [ "$1" = 'mysqld' ]; then
 
 		mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
 		
-		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		if [ "$MYSQL_RANDOM_ROOT_PASSWORD" == "yes" -o "$MYSQL_RANDOM_ROOT_PASSWORD" == "true" ]; then
 			MYSQL_ROOT_PASSWORD="$(pwmake 128)"
 			echo "[Entrypoint] GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
 		fi

--- a/5.7/docker-entrypoint.sh
+++ b/5.7/docker-entrypoint.sh
@@ -103,7 +103,7 @@ if [ "$1" = 'mysqld' ]; then
 
 		mysql_tzinfo_to_sql /usr/share/zoneinfo | "${mysql[@]}" mysql
 		
-		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		if [ "$MYSQL_RANDOM_ROOT_PASSWORD" == "yes" -o "$MYSQL_RANDOM_ROOT_PASSWORD" == "true" ]; then
 			MYSQL_ROOT_PASSWORD="$(pwmake 128)"
 			echo "[Entrypoint] GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
 		fi

--- a/8.0/docker-entrypoint.sh
+++ b/8.0/docker-entrypoint.sh
@@ -103,7 +103,7 @@ if [ "$1" = 'mysqld' ]; then
 
 		mysql_tzinfo_to_sql /usr/share/zoneinfo | "${mysql[@]}" mysql
 		
-		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		if [ "$MYSQL_RANDOM_ROOT_PASSWORD" == "yes" -o "$MYSQL_RANDOM_ROOT_PASSWORD" == "true" ]; then
 			MYSQL_ROOT_PASSWORD="$(pwmake 128)"
 			echo "[Entrypoint] GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
 		fi

--- a/template/docker-entrypoint.sh
+++ b/template/docker-entrypoint.sh
@@ -103,7 +103,7 @@ if [ "$1" = 'mysqld' ]; then
 
 		mysql_tzinfo_to_sql /usr/share/zoneinfo | %%SED_TZINFO%%"${mysql[@]}" mysql
 		
-		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+		if [ "$MYSQL_RANDOM_ROOT_PASSWORD" == "yes" -o "$MYSQL_RANDOM_ROOT_PASSWORD" == "true" ]; then
 			MYSQL_ROOT_PASSWORD="$(pwmake 128)"
 			echo "[Entrypoint] GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
 		fi


### PR DESCRIPTION
## Background
I'm working on an app that uses the `mysql:5.7` image, and set `MYSQL_RANDOM_ROOT_PASSWORD` to `no` (as opposed to `yes`, as per the documentation), to disable random root password generation.

## Problem
Setting `MYSQL_RANDOM_ROOT_PASSWORD` to _any_ non-empty value implies truthfulness - so `MYSQL_RANDOM_ROOT_PASSWORD=no` is treated the same as `MYSQL_RANDOM_ROOT_PASSWORD=yes`, which isn't very logical.

## PR Changes
Rather than testing for a non-empty value for `MYSQL_RANDOM_ROOT_PASSWORD` in `docker-entrypoint.sh`, I've changed it to test whether the environment variable's value is equal to `yes` or `true`.