### PR TITLE
Since mysql dir exists in the container need to check if mysql folder…

### DIFF
--- a/5.6/docker-entrypoint.sh
+++ b/5.6/docker-entrypoint.sh
@@ -53,7 +53,7 @@ if [ "$1" = 'mysqld' ]; then
 		fi
 	fi
 
-	if [ ! -d "$DATADIR/mysql" ]; then
+	if [[ ! -d "$DATADIR/mysql"   || ! `ls -A $DATADIR/mysql` ]]; then
 		# If the password variable is a filename we use the contents of the file. We
 		# read this first to make sure that a proper error is generated for empty files.
 		if [ -f "$MYSQL_ROOT_PASSWORD" ]; then


### PR DESCRIPTION
Since mysql dir exists in the container need to check if mysql folder is empty as well for running custom scripts.
Currently need to make workaround to make this works need to make workaround.
see stackoverflow [issue](https://stackoverflow.com/questions/38504257/mysql-scripts-in-docker-entrypoint-initdb-are-not-executed/52715521)

