### PR TITLE
Improve security permissions in docker images

### DIFF
--- a/mysql-cluster/7.5/Dockerfile
+++ b/mysql-cluster/7.5/Dockerfile
@@ -40,6 +40,8 @@ COPY cnf/mysql-cluster.cnf /etc/
 
 ENTRYPOINT ["/entrypoint.sh"]
 HEALTHCHECK CMD /healthcheck.sh
+
+USER mysql
 EXPOSE 3306 33060 2202 1186
 CMD ["mysqld"]
 

--- a/mysql-cluster/7.6/Dockerfile
+++ b/mysql-cluster/7.6/Dockerfile
@@ -40,6 +40,8 @@ COPY cnf/mysql-cluster.cnf /etc/
 
 ENTRYPOINT ["/entrypoint.sh"]
 HEALTHCHECK CMD /healthcheck.sh
+
+USER mysql
 EXPOSE 3306 33060 2202 1186
 CMD ["mysqld"]
 

--- a/mysql-cluster/8.0/Dockerfile
+++ b/mysql-cluster/8.0/Dockerfile
@@ -42,6 +42,8 @@ COPY cnf/mysql-cluster.cnf /etc/
 
 ENTRYPOINT ["/entrypoint.sh"]
 HEALTHCHECK CMD /healthcheck.sh
+
+USER mysql
 EXPOSE 3306 33060 2202 1186
 CMD ["mysqld"]
 

--- a/mysql-server/5.7/Dockerfile
+++ b/mysql-server/5.7/Dockerfile
@@ -39,6 +39,8 @@ COPY docker-entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh
 ENTRYPOINT ["/entrypoint.sh"]
 HEALTHCHECK CMD /healthcheck.sh
+
+USER mysql
 EXPOSE 3306 33060
 CMD ["mysqld"]
 

--- a/mysql-server/8.0/Dockerfile
+++ b/mysql-server/8.0/Dockerfile
@@ -39,6 +39,8 @@ COPY docker-entrypoint.sh /entrypoint.sh
 COPY healthcheck.sh /healthcheck.sh
 ENTRYPOINT ["/entrypoint.sh"]
 HEALTHCHECK CMD /healthcheck.sh
+
+USER mysql
 EXPOSE 3306 33060 33061
 CMD ["mysqld"]
 


### PR DESCRIPTION
According to docker best practises it is not recommended to run docker with root permissions. So it is better to use `mysql` user to run docker