### PR TITLE
MySQL is already initialized

### DIFF
--- a/mysql-server/8.0/docker-entrypoint.sh
+++ b/mysql-server/8.0/docker-entrypoint.sh
@@ -201,10 +201,10 @@ EOF
 
 		echo
 		echo '[Entrypoint] MySQL init process done. Ready for start up.'
-		echo
 	else
  		echo '[Entrypoint] MySQL already initialized in: $DATADIR/mysql' 
 	fi
+ 	echo 
 
 	# Used by healthcheck to make sure it doesn't mistakenly report container
 	# healthy during startup

--- a/mysql-server/8.0/docker-entrypoint.sh
+++ b/mysql-server/8.0/docker-entrypoint.sh
@@ -202,6 +202,8 @@ EOF
 		echo
 		echo '[Entrypoint] MySQL init process done. Ready for start up.'
 		echo
+	else
+ 		echo '[Entrypoint] MySQL already initialized in: $DATADIR/mysql' 
 	fi
 
 	# Used by healthcheck to make sure it doesn't mistakenly report container


### PR DESCRIPTION
Hi 

I spent a lot of time figuring out why my MySQL container wasn't picking up the various new "ENVIRONMENT" settings, but after running some tests I realized that the database had already been initialized on a local volume. 

I suggest making this simple modification to log this scenario.